### PR TITLE
fix: use JSON arguments for entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM cgr.dev/chainguard/wolfi-base AS go
 RUN apk update && apk add ca-certificates-bundle build-base openssh git go-1.24~=1.24.0
-ENTRYPOINT /usr/bin/go
+ENTRYPOINT ["/usr/bin/go"]


### PR DESCRIPTION
See https://docs.docker.com/go/dockerfile/rule/json-args-recommended/