### PR TITLE
feat: go 1.25.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM cgr.dev/chainguard/wolfi-base AS go
-RUN apk update && apk add ca-certificates-bundle build-base openssh git go-1.25~=1.25.4
+RUN apk update && apk add ca-certificates-bundle build-base openssh git go-1.25~=1.25.5
 ENTRYPOINT ["/usr/bin/go"]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the Docker build image to use Go 1.25.5 instead of 1.25.4. Keeps the toolchain current with the latest bug fixes and security updates.

<sup>Written for commit b363a55fa1c890f0c50cf0aa0651bc184e837dd1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain to a newer patch version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->