### PR TITLE
feat: go 1.25.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM cgr.dev/chainguard/wolfi-base AS go
-RUN apk update && apk add ca-certificates-bundle build-base openssh git go-1.25~=1.25.5
+RUN apk update && apk add ca-certificates-bundle build-base openssh git go-1.25~=1.25.6
 ENTRYPOINT ["/usr/bin/go"]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the Docker build image to Go 1.25.6 (was 1.25.5) to pick up the latest bug fixes and security patches.

<sup>Written for commit 98b3e0ff7c30998c467ac01b99ac3628eff2788a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

