### PR TITLE
feat: go 1.25.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM cgr.dev/chainguard/wolfi-base AS go
-RUN apk update && apk add ca-certificates-bundle build-base openssh git go-1.25~=1.25.6
+RUN apk update && apk add ca-certificates-bundle build-base openssh git go-1.25~=1.25.7
 ENTRYPOINT ["/usr/bin/go"]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the Wolfi-based Docker image to install Go 1.25.7 instead of 1.25.6. Pulls in the latest patch fixes for the Go toolchain.

<sup>Written for commit 8aee4b81f0eaa627b911911b4ac7f11dceeec02f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain package version in Docker build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->