### PR TITLE
feat: go 1.25.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM cgr.dev/chainguard/wolfi-base AS go
-RUN apk update && apk add ca-certificates-bundle build-base openssh git go-1.25~=1.25.7
+RUN apk update && apk add ca-certificates-bundle build-base openssh git go-1.25~=1.25.8
 ENTRYPOINT ["/usr/bin/go"]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade Go in the Docker build image from 1.25.7 to 1.25.8 to pull in the latest patch fixes. This updates the build toolchain only.

<sup>Written for commit a36c5732bf53eeb65418d160bf358f24a42ab4b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go runtime to the latest patch version for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->