### PR TITLE
feat: go 1.26.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM cgr.dev/chainguard/wolfi-base AS go
-RUN apk update && apk add ca-certificates-bundle build-base openssh git go-1.25~=1.25.8
+RUN apk update && apk add ca-certificates-bundle build-base openssh git go-1.26~=1.26.1
 ENTRYPOINT ["/usr/bin/go"]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade the build image to Go 1.26.1 for the latest toolchain and patches. Dockerfile now installs `go-1.26~=1.26.1` instead of `go-1.25~=1.25.8`.

<sup>Written for commit d1e4f25c3bfc3b50012965360f59feb89dca9983. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go runtime to version 1.26~=1.26.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->