### PR TITLE
feat: go 1.26.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM cgr.dev/chainguard/wolfi-base AS go
-RUN apk update && apk add ca-certificates-bundle build-base openssh git go-1.26~=1.26.1
+RUN apk update && apk add ca-certificates-bundle build-base openssh git go-1.26~=1.26.3
 ENTRYPOINT ["/usr/bin/go"]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade Go toolchain in the Docker image from 1.26.1 to 1.26.3 via the Wolfi `go-1.26` package. Pulls in the latest patch fixes with no other changes.

<sup>Written for commit e3b0def59052e2dbdc04388ac1f2fbe41bf2c29b. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/docker-go/pull/101?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

