### PR TITLE
chore: replace inline workflows with reusable workflow wrappers

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -1,34 +1,16 @@
-name: Docker CI
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "Docker CI"
 
 on:
   pull_request:
-    branches: ['main']
-    paths: ['Dockerfile','.github/workflows/ci-docker.yml']
-
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: blinklabs-io/go
-
-permissions:
-  contents: read
+    branches:
+      - main
+    paths:
+      - Dockerfile
+      - .github/workflows/ci-docker.yml
 
 jobs:
-  docker:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
-      - name: qemu
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0 https://github.com/docker/setup-qemu-action/releases/tag/v4.1.0
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0 https://github.com/docker/setup-buildx-action/releases/tag/v4.1.0
-      - id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0 https://github.com/docker/metadata-action/releases/tag/v6.1.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-      - name: build
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0 https://github.com/docker/build-push-action/releases/tag/v7.2.0
-        with:
-          context: .
-          push: false
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-ci-docker.yml@main
+    with:
+      image-name: blinklabs-io/go

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,17 +1,9 @@
-# The below is pulled from upstream and slightly modified
-# https://github.com/webiny/action-conventional-commits/blob/master/README.md#usage
-
-name: Conventional Commits
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "Conventional Commits"
 
 on:
   pull_request:
 
 jobs:
-  build:
-    name: Conventional Commits
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
-      - uses: webiny/action-conventional-commits@7f91b1595ca1951cdb671ddc9f07a49081ec5b69 # v1.4.2 https://github.com/webiny/action-conventional-commits/releases/tag/v1.4.2
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-conventional-commits.yml@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,86 +1,23 @@
-name: publish
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "publish"
 
 on:
   push:
-    branches: ['main']
+    branches:
+      - main
     tags:
-      - 'v*.*.*'
+      - v*.*.*
 
-concurrency: ${{ github.ref }}
+permissions:
+  contents: write
+  packages: write
 
 jobs:
-  build-and-push-image:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
-      - name: qemu
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0 https://github.com/docker/setup-qemu-action/releases/tag/v4.1.0
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0 https://github.com/docker/setup-buildx-action/releases/tag/v4.1.0
-      - name: Login to Docker Hub
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0 https://github.com/docker/login-action/releases/tag/v4.2.0
-        with:
-          username: blinklabs
-          password: ${{ secrets.DOCKER_PASSWORD }} # uses token
-      - name: Login to GHCR
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0 https://github.com/docker/login-action/releases/tag/v4.2.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0 https://github.com/docker/metadata-action/releases/tag/v6.1.0
-        with:
-          images: |
-            blinklabs/go
-            ghcr.io/blinklabs-io/go
-          tags: |
-            # version
-            type=match,pattern=v(.*),group=1
-            # branch
-            type=ref,event=branch
-      - name: push
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0 https://github.com/docker/build-push-action/releases/tag/v7.2.0
-        with:
-          context: .
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-      # Update Docker Hub from README
-      - name: Docker Hub Description
-        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0 https://github.com/peter-evans/dockerhub-description/releases/tag/v5.0.0
-        with:
-          username: blinklabs
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: blinklabs/go
-          readme-filepath: ./README.md
-          short-description: "Go image built from Chainguard Wolfi"
-
-  github-release:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    needs: [build-and-push-image]
-    steps:
-      - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 https://github.com/actions/github-script/releases/tag/v9.0.0
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            try {
-              await github.rest.repos.createRelease({
-                draft: false,
-                generate_release_notes: true,
-                name: process.env.RELEASE_TAG,
-                owner: context.repo.owner,
-                prerelease: false,
-                repo: context.repo.repo,
-                tag_name: process.env.RELEASE_TAG,
-              });
-            } catch (error) {
-              core.setFailed(error.message);
-            }
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-publish-docker.yml@main
+    secrets:
+      docker-password: ${{ secrets.DOCKER_PASSWORD }}
+    with:
+      docker-image: blinklabs/go
+      ghcr-image: blinklabs-io/go
+      description: "Go image built from Chainguard Wolfi"

--- a/.github/workflows/test-issue-on-close.yml
+++ b/.github/workflows/test-issue-on-close.yml
@@ -1,23 +1,14 @@
-name: Test Issue Close Trigger
-permissions:
-  contents: read
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "Test Issue Close Trigger"
+
 on:
   issues:
-    types: [closed]
+    types:
+      - closed
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Print closed issue info
-        env:
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ISSUE_TITLE: ${{ github.event.issue.title }}
-        run: |
-          echo "Issue Number: $ISSUE_NUMBER"
-          # Prevent workflow command injection from untrusted issue titles
-          TOKEN=$(uuidgen)
-          echo "::stop-commands::${TOKEN}"
-          echo "Title: $ISSUE_TITLE"
-          echo "::${TOKEN}::"
-          echo "Workflow triggered successfully when issue was closed."
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-test-issue-on-close.yml@main
+    with:
+      issue_number: ${{ github.event.issue.number }}
+      issue_title: ${{ github.event.issue.title }}

--- a/.github/workflows/update-issue-on-close.yml
+++ b/.github/workflows/update-issue-on-close.yml
@@ -1,39 +1,18 @@
-name: Set Project Closed Date
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "Set Project Closed Date"
 
 on:
   issues:
-    types: [closed]
-
-permissions:
-  contents: read
-  issues: read
-
-env:
-  PROJECT_URL: https://github.com/orgs/blinklabs-io/projects/11
-  CLOSED_DATE_FIELD: "Closed Date"
+    types:
+      - closed
+  workflow_dispatch:
 
 jobs:
-  set-date:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Resolve closed date
-        id: when
-        shell: bash
-        run: |
-          ts='${{ github.event.issue.closed_at }}'
-          if [ -z "$ts" ] || [ "$ts" = "null" ]; then
-            echo "Error: closed_at timestamp is missing or null. Refusing to set an incorrect closed date." >&2
-            exit 1
-          fi
-          d=$(date -u -d "$ts" +%F)
-          echo "date=$d" >> "$GITHUB_OUTPUT"
-          echo "Closed date -> $d"
-
-      # Update the "Closed Date" field on that project item
-      - name: Update Closed Date field
-        uses: nipe0324/update-project-v2-item-field@c4af58452d1c5a788c1ea4f20e073fa722ec4a6b
-        with:
-          project-url: ${{ env.PROJECT_URL }}
-          github-token: ${{ secrets.ORG_PROJECT_PAT }}
-          field-name: ${{ env.CLOSED_DATE_FIELD }}
-          field-value: ${{ steps.when.outputs.date }}
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-set-project-closed-date.yml@main
+    secrets:
+      project_pat: ${{ secrets.ORG_PROJECT_PAT }}
+    with:
+      closed_at: ${{ github.event.issue.closed_at }}
+      closed_date_field: Closed Date
+      project_url: https://github.com/orgs/blinklabs-io/projects/11


### PR DESCRIPTION
## Summary

Replaces all inline workflow definitions with thin wrappers that call the centrally governed reusable workflows from `blinklabs-io/actions`.

### Workflow mapping

| File | Reusable called |
|---|---|
| `conventional-commits.yml` | `reuseable-conventional-commits.yml@main` |
| `ci-docker.yml` | `reuseable-ci-docker.yml@main` |
| `publish.yml` | `reuseable-publish-docker.yml@main` (new — Docker-image-only publish) |
| `test-issue-on-close.yml` | `reuseable-test-issue-on-close.yml@main` |
| `update-issue-on-close.yml` | `reuseable-set-project-closed-date.yml@main` |

### Notes
- `publish.yml` uses a **new** `reuseable-publish-docker.yml` (not the binary publish reusable) since docker-go publishes Docker images only — no Go binaries.
- The actions governance PR (`feat/docker-go-governance`) adds `reuseable-publish-docker.yml` to the actions repo and must be merged before publish can run end-to-end.
- `ci-docker.yml` and `conventional-commits.yml` will run on this PR to validate the reusable calls.

/draft

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced all inline GitHub Actions with thin wrappers that call reusable workflows from `blinklabs-io/actions`. This reduces duplication and centralizes CI/CD control.

- **Refactors**
  - `ci-docker.yml` → `reuseable-ci-docker.yml@main` (image: blinklabs-io/go)
  - `conventional-commits.yml` → `reuseable-conventional-commits.yml@main`
  - `publish.yml` → `reuseable-publish-docker.yml@main` (Docker-only publish; Docker Hub + GHCR; description set)
  - `test-issue-on-close.yml` → `reuseable-test-issue-on-close.yml@main`
  - `update-issue-on-close.yml` → `reuseable-set-project-closed-date.yml@main`

- **Dependencies**
  - Requires the new `reuseable-publish-docker.yml` in `blinklabs-io/actions` (merge `feat/docker-go-governance`) before publish runs end-to-end.

<sup>Written for commit 44921c4ffa83a04008d788caa59dd0b424ea615a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/docker-go/pull/105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

